### PR TITLE
GHA's cron is UTC

### DIFF
--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -3,7 +3,7 @@ name: Corona-Dashboard-Scraper
 on: 
   push:
   schedule:
-    - cron: '6 10,11,12,13,19 * * *'
+    - cron: '6 8,9,10,11,17 * * *'
 
 jobs:
 

--- a/README.md
+++ b/README.md
@@ -344,4 +344,4 @@ If you find bugs in the code or in the data, please let me know by opening an is
 
 Repository: [https://github.com/knudmoeller/berlin_corona_cases](https://github.com/knudmoeller/berlin_corona_cases)
 
-Last changed: 2021-06-03
+Last changed: 2021-06-04

--- a/data/target/berlin_corona_cases.json
+++ b/data/target/berlin_corona_cases.json
@@ -1,5 +1,133 @@
 [
   {
+    "date": "2021-06-04",
+    "source": "https://www.berlin.de/corona/lagebericht/desktop/corona.html",
+    "counts_per_district": {
+      "lor_01": {
+        "case_count": 22569,
+        "indicence": 5850.7,
+        "recovered": 22002
+      },
+      "lor_02": {
+        "case_count": 14508,
+        "indicence": 4996.1,
+        "recovered": 14209
+      },
+      "lor_03": {
+        "case_count": 15117,
+        "indicence": 3693.1,
+        "recovered": 14713
+      },
+      "lor_04": {
+        "case_count": 15192,
+        "indicence": 4421.5,
+        "recovered": 14680
+      },
+      "lor_05": {
+        "case_count": 13721,
+        "indicence": 5595.9,
+        "recovered": 13180
+      },
+      "lor_06": {
+        "case_count": 12664,
+        "indicence": 4084.2,
+        "recovered": 12110
+      },
+      "lor_07": {
+        "case_count": 17551,
+        "indicence": 5000.5,
+        "recovered": 16913
+      },
+      "lor_08": {
+        "case_count": 20920,
+        "indicence": 6341.0,
+        "recovered": 20104
+      },
+      "lor_09": {
+        "case_count": 9833,
+        "indicence": 3592.8,
+        "recovered": 9495
+      },
+      "lor_10": {
+        "case_count": 10958,
+        "indicence": 4059.0,
+        "recovered": 10498
+      },
+      "lor_11": {
+        "case_count": 12062,
+        "indicence": 4099.9,
+        "recovered": 11645
+      },
+      "lor_12": {
+        "case_count": 13840,
+        "indicence": 5195.0,
+        "recovered": 13404
+      }
+    },
+    "counts_per_age_group": {
+      "0-4": {
+        "case_count": 4584,
+        "incidence": 2372.3
+      },
+      "5-9": {
+        "case_count": 6083,
+        "incidence": 3557.2
+      },
+      "10-14": {
+        "case_count": 7471,
+        "incidence": 4810.5
+      },
+      "15-19": {
+        "case_count": 9458,
+        "incidence": 6373.4
+      },
+      "20-24": {
+        "case_count": 13796,
+        "incidence": 6829.2
+      },
+      "25-29": {
+        "case_count": 16686,
+        "incidence": 5956.4
+      },
+      "30-39": {
+        "case_count": 33759,
+        "incidence": 5393.9
+      },
+      "40-49": {
+        "case_count": 25621,
+        "incidence": 5581.6
+      },
+      "50-59": {
+        "case_count": 25265,
+        "incidence": 4814.1
+      },
+      "60-69": {
+        "case_count": 13948,
+        "incidence": 3604.2
+      },
+      "70-79": {
+        "case_count": 9411,
+        "incidence": 3021.4
+      },
+      "80-89": {
+        "case_count": 8902,
+        "incidence": 4914.5
+      },
+      "90+": {
+        "case_count": 3276,
+        "incidence": 10887.0
+      },
+      "unknown": {
+        "case_count": 675,
+        "indidence": "n.a."
+      },
+      "* Fälle pro 100 000 Einwohner*innen. Datenquelle Berliner Bevölkerung: Statistisches Bundesamt, Bevölkerungsfortschreibung, Stichtag 31.12.2019": {
+        "case_count": 0,
+        "incidence": "unknown"
+      }
+    }
+  },
+  {
     "date": "2021-06-03",
     "source": "https://www.berlin.de/corona/lagebericht/desktop/corona.html",
     "counts_per_district": {

--- a/data/target/berlin_corona_traffic_light.json
+++ b/data/target/berlin_corona_traffic_light.json
@@ -1,6 +1,33 @@
 [
   {
     "source": "https://www.berlin.de/corona/lagebericht/desktop/corona.html",
+    "pr_date": "2021-06-04",
+    "indicators": {
+      "basic_reproduction_number": {
+        "color": "green",
+        "value": 0.85
+      },
+      "incidence_new_infections": {
+        "color": "yellow",
+        "value": 28.7
+      },
+      "icu_occupancy_rate": {
+        "color": "green",
+        "value": 11.7
+      },
+      "change_incidence": {
+        "color": "green",
+        "value": -12
+      }
+    },
+    "vaccination": {
+      "total_administered": 2284942,
+      "percentage_one_dose": 43.3,
+      "percentage_two_doses": 19.0
+    }
+  },
+  {
+    "source": "https://www.berlin.de/corona/lagebericht/desktop/corona.html",
     "pr_date": "2021-06-03",
     "indicators": {
       "basic_reproduction_number": {

--- a/data/target/berlin_corona_traffic_light.latest.json
+++ b/data/target/berlin_corona_traffic_light.latest.json
@@ -1,27 +1,27 @@
 {
   "source": "https://www.berlin.de/corona/lagebericht/desktop/corona.html",
-  "pr_date": "2021-06-03",
+  "pr_date": "2021-06-04",
   "indicators": {
     "basic_reproduction_number": {
       "color": "green",
-      "value": 0.84
+      "value": 0.85
     },
     "incidence_new_infections": {
-      "color": "red",
-      "value": 31.4
+      "color": "yellow",
+      "value": 28.7
     },
     "icu_occupancy_rate": {
       "color": "green",
-      "value": 11.6
+      "value": 11.7
     },
     "change_incidence": {
       "color": "green",
-      "value": -15
+      "value": -12
     }
   },
   "vaccination": {
-    "total_administered": 2230894,
-    "percentage_one_dose": 42.4,
-    "percentage_two_doses": 18.4
+    "total_administered": 2284942,
+    "percentage_one_dose": 43.3,
+    "percentage_two_doses": 19
   }
 }


### PR DESCRIPTION
Hey! Apparently GHA runs cron on UTC timezone, so this PR [adapts Berlin time to that one](https://www.worldtimebuddy.com/utc-to-germany-berlin), since the dashboard seems to be delivering updates earlier lately!