### PR TITLE
do not try to parse R number

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,4 +344,4 @@ If you find bugs in the code or in the data, please let me know by opening an is
 
 Repository: [https://github.com/knudmoeller/berlin_corona_cases](https://github.com/knudmoeller/berlin_corona_cases)
 
-Last changed: 2021-07-22
+Last changed: 2021-07-23

--- a/bin/scrape_dashboard.rb
+++ b/bin/scrape_dashboard.rb
@@ -75,8 +75,8 @@ def german_to_international_float(text)
     value
 end
 
-# scraping hell: I need to look at the style attribute of the element to 
-# determine the color of the traffic light. 
+# scraping hell: I need to look at the style attribute of the element to
+# determine the color of the traffic light.
 def extract_color(css)
     css.split(";").each do |rule|
         parsed = rule.split(":")
@@ -130,13 +130,13 @@ if ARGV.count == 3
             :counts_per_district => extract_district_data(doc) ,
             :counts_per_age_group => extract_age_group_data(doc)
         }
-        
+
         current_case_numbers.unshift(new_case_numbers)
     end
     File.open(File.join(temp_folder, "berlin_corona_cases.json"), "wb") do |file|
         file.puts JSON.pretty_generate(current_case_numbers)
     end
-            
+
     LOGGER.info("extracting traffic light and vaccination data ...")
     last_traffic_light_date = current_traffic_light_data.first['pr_date']
     if last_traffic_light_date == Date.today.iso8601
@@ -147,32 +147,32 @@ if ARGV.count == 3
             :pr_date => dashboard_date.iso8601 ,
             :indicators => {
                 :basic_reproduction_number => {
-                    :color => extract_color(doc.at_css("#r-wert")['style']) ,
-                    :value => german_to_international_float(doc.css("#r-wert .inner .value").text())
+                    :color => "",
+                    :value => 0.0
                 } ,
                 :incidence_new_infections => {
                     :color => extract_color(doc.at_css("#neuinfektionen")['style']) ,
                     :value => german_to_international_float(doc.css("#neuinfektionen .inner .value").text())
-                } ,    
+                } ,
                 :icu_occupancy_rate => {
                     :color => extract_color(doc.at_css("#its")['style']) ,
                     :value => german_to_international_float(doc.css("#its .inner .value").text().gsub("%",""))
                 } ,
                 :change_incidence => {
                     :color => extract_color(doc.at_css("#rel_7TI")['style']) ,
-                    :value => german_to_international_float(doc.css("#rel_7TI .inner .value").text().gsub("%","")).to_i                     
+                    :value => german_to_international_float(doc.css("#rel_7TI .inner .value").text().gsub("%","")).to_i
                 }
             } ,
             :vaccination => {
-               :total_administered => 
+               :total_administered =>
                     doc.css("#box-Impfdosen .inner .value").text().gsub(" ","").to_i ,
-               :percentage_one_dose => 
+               :percentage_one_dose =>
                     german_to_international_float(doc.css("#box-erstimpfung .inner .value").text().gsub("%","")) ,
-                :percentage_two_doses => 
-                    german_to_international_float(doc.css("#box-zweitimpfung .inner .value").text().gsub("%","")) 
-            }   
+                :percentage_two_doses =>
+                    german_to_international_float(doc.css("#box-zweitimpfung .inner .value").text().gsub("%",""))
+            }
         }
-        
+
         current_traffic_light_data.unshift(new_traffic_light)
     end
     File.open(File.join(temp_folder, "berlin_corona_traffic_light.json"), "wb") do |file|

--- a/data/target/berlin_corona_cases.json
+++ b/data/target/berlin_corona_cases.json
@@ -1,5 +1,133 @@
 [
   {
+    "date": "2021-07-23",
+    "source": "https://www.berlin.de/corona/lagebericht/desktop/corona.html",
+    "counts_per_district": {
+      "lor_01": {
+        "case_count": 22761,
+        "indicence": 5900.5,
+        "recovered": 22275
+      },
+      "lor_02": {
+        "case_count": 14881,
+        "indicence": 5124.6,
+        "recovered": 14533
+      },
+      "lor_03": {
+        "case_count": 15382,
+        "indicence": 3757.8,
+        "recovered": 15002
+      },
+      "lor_04": {
+        "case_count": 15529,
+        "indicence": 4519.6,
+        "recovered": 15060
+      },
+      "lor_05": {
+        "case_count": 13965,
+        "indicence": 5695.4,
+        "recovered": 13644
+      },
+      "lor_06": {
+        "case_count": 12812,
+        "indicence": 4132.0,
+        "recovered": 12330
+      },
+      "lor_07": {
+        "case_count": 17797,
+        "indicence": 5070.6,
+        "recovered": 17212
+      },
+      "lor_08": {
+        "case_count": 21080,
+        "indicence": 6389.5,
+        "recovered": 20569
+      },
+      "lor_09": {
+        "case_count": 9970,
+        "indicence": 3642.8,
+        "recovered": 9705
+      },
+      "lor_10": {
+        "case_count": 11121,
+        "indicence": 4119.4,
+        "recovered": 10821
+      },
+      "lor_11": {
+        "case_count": 12219,
+        "indicence": 4153.3,
+        "recovered": 11910
+      },
+      "lor_12": {
+        "case_count": 14011,
+        "indicence": 5259.2,
+        "recovered": 13646
+      }
+    },
+    "counts_per_age_group": {
+      "0-4": {
+        "case_count": 4668,
+        "incidence": 2415.7
+      },
+      "5-9": {
+        "case_count": 6213,
+        "incidence": 3633.2
+      },
+      "10-14": {
+        "case_count": 7636,
+        "incidence": 4916.7
+      },
+      "15-19": {
+        "case_count": 9656,
+        "incidence": 6506.8
+      },
+      "20-24": {
+        "case_count": 14214,
+        "incidence": 7036.1
+      },
+      "25-29": {
+        "case_count": 17158,
+        "incidence": 6124.9
+      },
+      "30-39": {
+        "case_count": 34411,
+        "incidence": 5498.1
+      },
+      "40-49": {
+        "case_count": 25893,
+        "incidence": 5640.9
+      },
+      "50-59": {
+        "case_count": 25425,
+        "incidence": 4844.6
+      },
+      "60-69": {
+        "case_count": 14045,
+        "incidence": 3629.3
+      },
+      "70-79": {
+        "case_count": 9437,
+        "incidence": 3029.8
+      },
+      "80-89": {
+        "case_count": 8922,
+        "incidence": 4925.6
+      },
+      "90+": {
+        "case_count": 3270,
+        "incidence": 10867.0
+      },
+      "unknown": {
+        "case_count": 580,
+        "indidence": "n.a."
+      },
+      "* Fälle pro 100 000 Einwohner*innen. Datenquelle Berliner Bevölkerung: Statistisches Bundesamt, Bevölkerungsfortschreibung, Stichtag 31.12.2019": {
+        "case_count": 0,
+        "incidence": "unknown"
+      }
+    }
+  },
+  {
     "date": "2021-07-22",
     "source": "https://www.berlin.de/corona/lagebericht/desktop/corona.html",
     "counts_per_district": {

--- a/data/target/berlin_corona_traffic_light.json
+++ b/data/target/berlin_corona_traffic_light.json
@@ -1,6 +1,33 @@
 [
   {
     "source": "https://www.berlin.de/corona/lagebericht/desktop/corona.html",
+    "pr_date": "2021-07-23",
+    "indicators": {
+      "basic_reproduction_number": {
+        "color": "",
+        "value": 0.0
+      },
+      "incidence_new_infections": {
+        "color": "yellow",
+        "value": 21.8
+      },
+      "icu_occupancy_rate": {
+        "color": "green",
+        "value": 3.8
+      },
+      "change_incidence": {
+        "color": "red",
+        "value": 78
+      }
+    },
+    "vaccination": {
+      "total_administered": 3839266,
+      "percentage_one_dose": 59.5,
+      "percentage_two_doses": 47.4
+    }
+  },
+  {
+    "source": "https://www.berlin.de/corona/lagebericht/desktop/corona.html",
     "pr_date": "2021-07-22",
     "indicators": {
       "basic_reproduction_number": {

--- a/data/target/berlin_corona_traffic_light.latest.json
+++ b/data/target/berlin_corona_traffic_light.latest.json
@@ -1,27 +1,27 @@
 {
   "source": "https://www.berlin.de/corona/lagebericht/desktop/corona.html",
-  "pr_date": "2021-07-22",
+  "pr_date": "2021-07-23",
   "indicators": {
     "basic_reproduction_number": {
-      "color": "green",
-      "value": 1.6
+      "color": "",
+      "value": 0
     },
     "incidence_new_infections": {
       "color": "yellow",
-      "value": 22.6
+      "value": 21.8
     },
     "icu_occupancy_rate": {
       "color": "green",
-      "value": 3.6
+      "value": 3.8
     },
     "change_incidence": {
       "color": "red",
-      "value": 108
+      "value": 78
     }
   },
   "vaccination": {
-    "total_administered": 3810391,
-    "percentage_one_dose": 59.3,
-    "percentage_two_doses": 46.8
+    "total_administered": 3839266,
+    "percentage_one_dose": 59.5,
+    "percentage_two_doses": 47.4
   }
 }


### PR DESCRIPTION
Closes #7 

R Factor is no longer displayed in the dashboard, but we should keep the key in the dict in case some apps are expecting it.

(sorry about the trailing whitespace diff; the IDE took it out)